### PR TITLE
Providing a healthcheck endpoint

### DIFF
--- a/src/nginx_conf.d/redirector.conf
+++ b/src/nginx_conf.d/redirector.conf
@@ -4,6 +4,13 @@ server {
     listen 80 default_server reuseport;
     listen [::]:80 default_server reuseport;
 
+    # Healthcheck path
+    location = /health {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 'Status-OK!';
+    }
+
     # Anything requesting this particular URL should be served content from
     # Certbot's folder so the HTTP-01 ACME challenges can be completed for the
     # HTTPS certificates.


### PR DESCRIPTION
This is to make sure docker healthcheck endpoint is accessible over HTTP.